### PR TITLE
fixed for burstcoin fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM openjdk:8-jdk-alpine
 
-ADD https://github.com/burst-team/burstcoin/releases/download/1.2.8/burstcoin-1.2.8.zip /app/burstcoin/
+ADD https://github.com/dawallet/burstcoin/releases/download/1.2.9c/burstcoin-1.2.9c.zip /app/burstcoin/
 
 COPY docker /app/burstcoin/docker
 
 WORKDIR /app/burstcoin
 
 RUN apk add --no-cache --no-progress unzip \
- && unzip burstcoin-1.2.8.zip \
+ && unzip burstcoin-1.2.9c.zip \
  && ./docker/finalize.ash \
  && apk del --no-progress unzip
 
@@ -16,4 +16,3 @@ VOLUME ["/data"]
 EXPOSE 8123 8125
 
 ENTRYPOINT ["/app/burstcoin/docker/start.ash"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM openjdk:8-jdk-alpine
 
-ADD https://github.com/dawallet/burstcoin/releases/download/1.2.9c/burstcoin-1.2.9c.zip /app/burstcoin/
+ADD https://github.com/burst-team/burstcoin/releases/download/1.2.9/burstcoin-1.2.9.zip /app/burstcoin/
 
 COPY docker /app/burstcoin/docker
 
 WORKDIR /app/burstcoin
 
 RUN apk add --no-cache --no-progress unzip \
- && unzip burstcoin-1.2.9c.zip \
+ && unzip burstcoin-1.2.9.zip \
  && ./docker/finalize.ash \
  && apk del --no-progress unzip
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *Ship your burstcoin wallet with Docker*
 
 ## Info
-Build a Docker image from openjdk:8-jdk-alpine and run burst-team/burstcoin release 1.2.8.
+Build a Docker image from openjdk:8-jdk-alpine and run ~burst-team/burstcoin release 1.2.8~ updated with dawallet/burstcoin release 1.2.9c.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ docker start burstcoin
 
 https://github.com/burst-team/burstcoin *Burstcoin Core Development on GitHub*
 
+https://github.com/dawallet/burstcoin *Faster updates on wallets for fork issues*
+
 https://docs.docker.com/engine/admin/host_integration *Start containers automatically*
 
 https://hub.docker.com/r/_/openjdk/ *openjdk image on Docker Hub*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 *Ship your burstcoin wallet with Docker*
 
 ## Info
-Build a Docker image from openjdk:8-jdk-alpine and run ~burst-team/burstcoin release 1.2.8~ updated with dawallet/burstcoin release 1.2.9c.
+Build a Docker image from openjdk:8-jdk-alpine and run burst-team/burstcoin release 1.2.9.
+
+This will be kept up to date with the newest releases.
 
 ## Build
 


### PR DESCRIPTION
changed wallet to 1.2.9 for fork and added link for sub updates from dawallet for quicker fixes.